### PR TITLE
Ensures tekton is installed before installing resources to fix issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 
 resource null_resource print_support_namespace {
   provisioner "local-exec" {
-    command = "echo 'Support namespace: ${var.support_namespace}'"
+    command = "echo 'Namespaces: support_namespace=${var.support_namespace}, tekton_namespace=${var.tekton_namespace}'"
   }
 }
 
@@ -28,6 +28,7 @@ data external latest_release {
 
 resource "null_resource" "tekton_resources" {
   count = var.cluster_type == "ocp4" ? 1 : 0
+  depends_on = [null_resource.print_support_namespace]
 
   triggers = {
     kubeconfig      = var.cluster_config_file_path

--- a/module.yaml
+++ b/module.yaml
@@ -18,6 +18,7 @@ versions:
         - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
           version: ">= 2.1.0"
     - id: tekton
+      optional: true
       interface: github.com/cloud-native-toolkit/automation-modules#tekton
       refs: []
     - id: buildah
@@ -43,6 +44,11 @@ versions:
       moduleRef:
         id: buildah
         output: namespace
+    - name: tekton_namespace
+      optional: true
+      moduleRef:
+        id: tekton
+        output: tekton_namespace
     - name: pre_tekton
       scope: ignore
     - name: revision

--- a/test/stages/stage2-tekton.tf
+++ b/test/stages/stage2-tekton.tf
@@ -12,4 +12,5 @@ module "dev_tools_tekton_resources" {
   cluster_config_file_path = module.dev_cluster.config_file_path
   resource_namespace       = module.dev_tools_namespace.name
   support_namespace        = module.buildah-unprivileged.namespace
+  tekton_namespace         = module.dev_tools_tekton.tekton_namespace
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,9 @@ variable "support_namespace" {
   description = "The namespace where supporting infrastructure and configuration are running (e.g. buildah-unprivileged daemon set)"
   default     = ""
 }
+
+variable "tekton_namespace" {
+  type        = string
+  description = "The namespace where tekton is running. This variable is used to make sure tekton has installed before installing the tekton resources"
+  default     = ""
+}


### PR DESCRIPTION
- Adds tekton_namespace variable that is wired to tekton module output to make sure tekton is installed before proceeding

closes #61

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>